### PR TITLE
Moving unicast peer loop inside unicast_peer tag

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -37,8 +37,8 @@ vrrp_instance {{ item.name }} {
 {% if item.use_unicast is defined and item.use_unicast %}
 
   unicast_src_ip {{ item.unicast_src_ip }}
-{% for peer in item.unicast_peers %}
   unicast_peer {
+{% for peer in item.unicast_peers %}
     {{ peer }}
 {% endfor %}
   }


### PR DESCRIPTION
This PR will fix the unicast peers generation.

Currently, unicast peers is generated in following way.

```
  unicast_peer {
    192.168.10.11
   unicast_peer {
    192.168.10.12
  }
```

After fix,

```
  unicast_peer {
    192.168.10.11
    192.168.10.12
  }
```